### PR TITLE
Compress concrete syntax folder structure

### DIFF
--- a/grammars/edu.umn.cs.melt.exts.ableC.vector/Exports.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.vector/Exports.sv
@@ -1,7 +1,6 @@
 grammar edu:umn:cs:melt:exts:ableC:vector;
 
-exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
-exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
+exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax;
 
 exports edu:umn:cs:melt:exts:ableC:string;
 exports edu:umn:cs:melt:exts:ableC:templating;

--- a/grammars/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/Constructor.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/Constructor.sv
@@ -1,14 +1,4 @@
-grammar edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
-
-imports edu:umn:cs:melt:ableC:concretesyntax;
-imports silver:langutil only ast;
-
-imports edu:umn:cs:melt:ableC:abstractsyntax;
-imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
-imports edu:umn:cs:melt:ableC:abstractsyntax:env;
---imports edu:umn:cs:melt:ableC:abstractsyntax:debug;
-
-import edu:umn:cs:melt:exts:ableC:vector;
+grammar edu:umn:cs:melt:exts:ableC:vector:concretesyntax;
 
 marking terminal Vec_t /vec[\ ]*</ lexer classes {Ckeyword};
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/TypeExpr.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/TypeExpr.sv
@@ -1,4 +1,4 @@
-grammar edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
+grammar edu:umn:cs:melt:exts:ableC:vector:concretesyntax;
 
 imports edu:umn:cs:melt:ableC:concretesyntax;
 imports silver:langutil only ast;
@@ -8,7 +8,7 @@ imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
 --imports edu:umn:cs:melt:ableC:abstractsyntax:debug;
 
-import edu:umn:cs:melt:exts:ableC:vector;
+imports edu:umn:cs:melt:exts:ableC:vector;
 
 marking terminal Vector_t /vector[\ ]*</ lexer classes {Ckeyword};
 

--- a/modular_analyses/determinism/MDA.sv
+++ b/modular_analyses/determinism/MDA.sv
@@ -7,10 +7,6 @@ grammar determinism;
 
 import edu:umn:cs:melt:ableC:host;
 
-copper_mda testTypeExpr(ablecParser) {
-  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
-}
-
-copper_mda testConstructor(ablecParser) {
-  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
+copper_mda testConcreteSyntax(ablecParser) {
+  edu:umn:cs:melt:exts:ableC:vector:concretesyntax;
 }


### PR DESCRIPTION
This compresses the concrete syntax folders of this extension to be a single folder.